### PR TITLE
Fixes relative to the full hours

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,11 +154,12 @@ document.addEventListener("DOMContentLoaded", function () {
     }
     function chimeHourly() {
         chime0q.removeEventListener('ended', chimeHourly);
+        currentTime = new Date();
         var hour = currentTime.getHours();
         var numStrike = hour % 12;
         if (numStrike === 0)
             numStrike = 12;
-        
+
         chimestrike.currentTime = chimeTime(12 - numStrike);
         chimestrike.play();
     }
@@ -174,12 +175,16 @@ document.addEventListener("DOMContentLoaded", function () {
 
         if (currentTime.getSeconds() === 0) {
             switch(currentTime.getMinutes()) {
-                case 0: chime0q.play(); chime0q.addEventListener('ended', chimeHourly); break;
                 case 15: chime1q.play(); break;
                 case 30: chime2q.play(); break;
                 case 45: chime3q.play(); break;
+            } else if (currentTime.getSeconds() === 38){
+              switch(currentTime.getMinutes()) {
+                case 59:
+                  chime0q.play();
+                  chime0q.addEventListener('ended', chimeHourly);
+              }
             }
-           
         }
     }
     setInterval(redraw, 1000);


### PR DESCRIPTION
Considering the informations here:
https://www.quora.com/Do-the-gongs-from-a-tower-bell-tell-you-the-exact-time

And some demonstrations in these videos:
https://www.youtube.com/watch?v=LiKOhOzQyZg
https://www.youtube.com/watch?v=wqslA_CKub8

I realized that:
1 - The quarterly chimes (xx:15, xx:30 and xx:45) are ok, beginning at xx:15:00 and so on.
2 - The big ben wasn't starting to strike at xx:00:00. The chimes announcing it (the full hour) was doing it (starting at xx:00:00).

Considering the length of the audio file relative to the "0q_chimes", these chimes would beginning (considering the context of full seconds, not milliseconds), around 38 seconds of the previous minute. I think it is not exactly the time when the real Big Ben start its full-hour-chimes, but using this audio files, this would be the needed point-of-start for the ben strikes at xx:00:00.

Hope you like it! ;)